### PR TITLE
Fix venue search exclusion option, document usage, and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - run: gem install jekyll
+      - run: ruby tests/test_publications.rb
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - run: gem install jekyll
+      - run: jekyll build

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # Google Scholar for GitHub Pages
-This is a Jekyll include file that pulls from a Google Scholar csv file to output and format your references. Using it is pretty simple!
-1. Download your Google Scholar publications in a csv. Make sure you get all of them. 
-2. Upload that csv file to the `_data/` directory of your site directory and make sure its named `citations.csv`.
+This is a Jekyll include file that pulls from a Google Scholar CSV file to output and format your references. Using it is pretty simple!
+
+1. Download your Google Scholar publications as a CSV. Make sure you get all of them.
+2. Upload that CSV file to the `_data/` directory of your site directory and make sure it's named `citations.csv`.
 3. Download the `publications` include file from this repository ([here](https://github.com/cmccomb/google-scholar-for-github-pages/blob/main/_includes/publications)).
 4. Upload that file to the `_includes/` directory of your site.
 5. That's it! You can see some usage examples and documentation [here](https://cmccomb.com/google-scholar-for-github-pages/).
 
+Optionally filter publications by passing parameters to the `publications` include. For example, set `venue_search_exclude` to a semicolon-separated list of venue terms to omit entries whose venue contains any of those terms.
+
 This is similar to [Jekyll Scholar](https://github.com/inukshuk/jekyll-scholar), but since this is a pure Liquid solution it works seamlessly with Github Pages!
+
+## Development
+
+Run the tests and build the site before publishing changes:
+
+```bash
+ruby tests/test_publications.rb
+jekyll build
+```
+
+A GitHub Actions workflow runs these commands automatically and only builds the site when the tests succeed.

--- a/_includes/publications
+++ b/_includes/publications
@@ -22,7 +22,7 @@
   {% assign venue_searchterms = include.venue_search | downcase | split: ";" %}
 {% endif %}
 
-{% if include.venue_seach_exclude %}
+{% if include.venue_search_exclude %}
   {% assign venue_searchterms_exclude = include.venue_search_exclude | downcase | split: ";" %}
 {% endif %}
 
@@ -91,12 +91,12 @@
     {% assign is_venue_search = true %}
   {% endif %}
   
-  {% if include.venue_search_exclue %}
+  {% if include.venue_search_exclude %}
     {% assign venue = citation.Publication | downcase %}
     {% assign is_venue_search_exclude = true %}
     {% for term in venue_searchterms_exclude %}
       {% if venue contains term %}
-        {% assign is_venue_search_exlude = false %}
+        {% assign is_venue_search_exclude = false %}
       {% endif %}
     {% endfor %}
   {% else %}

--- a/tests/fixtures/citations.csv
+++ b/tests/fixtures/citations.csv
@@ -1,0 +1,3 @@
+Authors,Title,Publication,Volume,Number,Pages,Year,Publisher
+"Doe, Jane; Smith, John;","Test Conference Paper","Design Conference",,,,2020,
+"Doe, Jane; Smith, John;","Test Journal Paper","Design Studies",,,,2021,

--- a/tests/test_publications.rb
+++ b/tests/test_publications.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require 'liquid'
+require 'csv'
+
+class PublicationsTemplateTest < Minitest::Test
+  def setup
+    fixture_path = File.expand_path('fixtures/citations.csv', __dir__)
+    @citations = CSV.read(fixture_path, headers: true).map(&:to_h)
+    template_path = File.expand_path('../_includes/publications', __dir__)
+    @template = Liquid::Template.parse(File.read(template_path))
+  end
+
+  def test_venue_search_exclude
+    context = {
+      'site' => { 'data' => { 'citations' => @citations } },
+      'include' => { 'venue_search' => 'design', 'venue_search_exclude' => 'conference' }
+    }
+    result = @template.render(context).downcase
+    assert_includes result, 'design studies'
+    refute_includes result, 'design conference'
+  end
+end


### PR DESCRIPTION
## Summary
- fix typos in `venue_search_exclude` logic
- document `venue_search_exclude` parameter in README and add development instructions
- add regression test for `venue_search_exclude`
- add CI workflow to run tests before building the site

## Testing
- `ruby tests/test_publications.rb`
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68bb628fa05883259bf6fd34035f9df6