### PR TITLE
Install jekyll theme dependency for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-      - run: gem install jekyll
+      - run: gem install jekyll -v 4.4.1 jekyll-theme-tactile -v 0.2.0
       - run: ruby tests/test_publications.rb
 
   build:
@@ -23,5 +23,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-      - run: gem install jekyll
+      - run: gem install jekyll -v 4.4.1 jekyll-theme-tactile -v 0.2.0
       - run: jekyll build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-      - run: gem install jekyll -v 4.4.1 jekyll-theme-tactile -v 0.2.0
+      - run: gem install 'jekyll:4.4.1' 'jekyll-theme-tactile:0.2.0'
       - run: ruby tests/test_publications.rb
 
   build:
@@ -23,5 +23,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-      - run: gem install jekyll -v 4.4.1 jekyll-theme-tactile -v 0.2.0
+      - run: gem install 'jekyll:4.4.1' 'jekyll-theme-tactile:0.2.0'
       - run: jekyll build

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is similar to [Jekyll Scholar](https://github.com/inukshuk/jekyll-scholar),
 Run the tests and build the site before publishing changes:
 
 ```bash
-gem install jekyll -v 4.4.1 jekyll-theme-tactile -v 0.2.0
+gem install 'jekyll:4.4.1' 'jekyll-theme-tactile:0.2.0'
 ruby tests/test_publications.rb
 jekyll build
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is similar to [Jekyll Scholar](https://github.com/inukshuk/jekyll-scholar),
 Run the tests and build the site before publishing changes:
 
 ```bash
+gem install jekyll -v 4.4.1 jekyll-theme-tactile -v 0.2.0
 ruby tests/test_publications.rb
 jekyll build
 ```


### PR DESCRIPTION
## Summary
- install `jekyll-theme-tactile` gem alongside `jekyll`
- document gem installation in development instructions

## Testing
- `ruby tests/test_publications.rb`
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68bcbcd1267c83259fa4f2eae60657db